### PR TITLE
Allow global buttons to receive touch events in resume states

### DIFF
--- a/Clew.xcodeproj/project.pbxproj
+++ b/Clew.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		B0A563F6FE1007A2716DC876 /* Pods_Clew_Dev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3532E390954571B93729786A /* Pods_Clew_Dev.framework */; };
 		B7EB59E220F693EB00FBBC6A /* Confirm.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 4DF05CC71F34EB56008B0E31 /* Confirm.mp3 */; };
 		B7EB59E320F693EB00FBBC6A /* Crumb.obj in Resources */ = {isa = PBXBuildFile; fileRef = 4D6B00E41F33C85500952242 /* Crumb.obj */; };
+		E538EF4F22D3BFEC004216E9 /* TransparentTouchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E538EF4E22D3BFEC004216E9 /* TransparentTouchView.swift */; };
+		E538EF5022D3BFEC004216E9 /* TransparentTouchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E538EF4E22D3BFEC004216E9 /* TransparentTouchView.swift */; };
 		E5470EF622C119F5001092A4 /* RecordButtonKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5470EAB22C119F4001092A4 /* RecordButtonKit.swift */; };
 		E5470EF722C119F5001092A4 /* RecordButtonKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5470EAB22C119F4001092A4 /* RecordButtonKit.swift */; };
 		E5470EF822C119F5001092A4 /* AudioVisualizerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5470EAC22C119F4001092A4 /* AudioVisualizerView.swift */; };
@@ -125,6 +127,7 @@
 		B7EB59EC20F693EB00FBBC6A /* Clew Dev.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Clew Dev.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C68778047D8E263D2FB04989 /* Pods-Clew Dev.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clew Dev.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Clew Dev/Pods-Clew Dev.debug.xcconfig"; sourceTree = "<group>"; };
 		D89DDB87A8AE1A9ECEAFCEC6 /* Pods-Clew.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Clew.release.xcconfig"; path = "Pods/Target Support Files/Pods-Clew/Pods-Clew.release.xcconfig"; sourceTree = "<group>"; };
+		E538EF4E22D3BFEC004216E9 /* TransparentTouchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransparentTouchView.swift; sourceTree = "<group>"; };
 		E5470EAB22C119F4001092A4 /* RecordButtonKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordButtonKit.swift; sourceTree = "<group>"; };
 		E5470EAC22C119F4001092A4 /* AudioVisualizerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioVisualizerView.swift; sourceTree = "<group>"; };
 		E5470EAD22C119F4001092A4 /* RecorderViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecorderViewController.swift; sourceTree = "<group>"; };
@@ -329,6 +332,7 @@
 				E5470ED822C119F4001092A4 /* UIViewExtensions.swift */,
 				E5470ED922C119F4001092A4 /* UIButtonExtensions.swift */,
 				E5470EDA22C119F4001092A4 /* Float4x4Extension.swift */,
+				E538EF4E22D3BFEC004216E9 /* TransparentTouchView.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -638,6 +642,7 @@
 				E5470F2E22C119F5001092A4 /* StopRecordingController.swift in Sources */,
 				E5470F0A22C119F5001092A4 /* AppDelegate.swift in Sources */,
 				E5470F2222C119F5001092A4 /* UIViewExtensions.swift in Sources */,
+				E538EF4F22D3BFEC004216E9 /* TransparentTouchView.swift in Sources */,
 				E5470F3C22C119F5001092A4 /* FeedbackViewController.swift in Sources */,
 				E5470F3422C119F5001092A4 /* StopNavigationController.swift in Sources */,
 				E5470F3E22C119F5001092A4 /* RoutesViewController.swift in Sources */,
@@ -675,6 +680,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E538EF5022D3BFEC004216E9 /* TransparentTouchView.swift in Sources */,
 				E5470F2F22C119F5001092A4 /* StopRecordingController.swift in Sources */,
 				E5470F0B22C119F5001092A4 /* AppDelegate.swift in Sources */,
 				E5470F2322C119F5001092A4 /* UIViewExtensions.swift in Sources */,

--- a/Clew/Controllers/StateViews/PauseTrackingController.swift
+++ b/Clew/Controllers/StateViews/PauseTrackingController.swift
@@ -8,18 +8,6 @@
 
 import UIKit
 
-class TransparentTouchView: UIView {
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        for view in self.subviews {
-            if view.isUserInteractionEnabled, view.point(inside: self.convert(point, to: view), with: event) {
-                return true
-            }
-        }
-        
-        return false
-    }
-}
-
 /// A View Controller for handling the pause route state
 /// also handles associated buttons
 class PauseTrackingController: UIViewController {

--- a/Clew/Controllers/StateViews/ResumeTrackingConfirmController.swift
+++ b/Clew/Controllers/StateViews/ResumeTrackingConfirmController.swift
@@ -31,10 +31,10 @@ class ResumeTrackingConfirmController: UIViewController {
                                           width: UIScreen.main.bounds.size.width-30,
                                           height: UIScreen.main.bounds.size.height/2))
         
-        view.frame = CGRect(x: 0,
-                            y: 0,
-                            width: UIScreen.main.bounds.size.width,
-                            height: UIScreen.main.bounds.size.height)
+        view = TransparentTouchView(frame: CGRect(x: 0,
+                                           y: 0,
+                                           width: UIScreen.main.bounds.size.width,
+                                           height: UIScreen.main.bounds.size.height))
         
 //        let label = UILabel(frame: CGRect(x: 15,
 //                                          y: UIScreen.main.bounds.size.height/5,

--- a/Clew/Controllers/StateViews/ResumeTrackingController.swift
+++ b/Clew/Controllers/StateViews/ResumeTrackingController.swift
@@ -18,10 +18,10 @@ class ResumeTrackingController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.frame = CGRect(x: 0,
-                            y: 0,
-                            width: UIScreen.main.bounds.size.width,
-                            height: UIScreen.main.bounds.size.height)
+        view = TransparentTouchView(frame:CGRect(x: 0,
+                                                 y: 0,
+                                                 width: UIScreen.main.bounds.size.width,
+                                                 height: UIScreen.main.bounds.size.height))
 
         let label = UILabel(frame: CGRect(x: 15,
                                           y: UIScreen.main.bounds.size.height/5,

--- a/Clew/Extensions/TransparentTouchView.swift
+++ b/Clew/Extensions/TransparentTouchView.swift
@@ -1,0 +1,21 @@
+//
+//  TransparentTouchView.swift
+//  Clew
+//
+//  Created by Dieter Brehm on 7/8/19.
+//  Copyright © 2019 OccamLab. All rights reserved.
+//
+
+import Foundation
+
+class TransparentTouchView: UIView {
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        for view in self.subviews {
+            if view.isUserInteractionEnabled, view.point(inside: self.convert(point, to: view), with: event) {
+                return true
+            }
+        }
+        
+        return false
+    }
+}


### PR DESCRIPTION
Improvement based on Co-Design session 1: Swapped the resume state views to use the transparent touch view UIView override so that touch events on our state classes' container views can pass touch events down the view hierarchy.

Result: when resuming a route navigation, you can press the home button in all button arrangements / app states.