### PR TITLE
Fix previously broken landmark label display

### DIFF
--- a/Clew/Controllers/StateViews/ResumeTrackingConfirmController.swift
+++ b/Clew/Controllers/StateViews/ResumeTrackingConfirmController.swift
@@ -95,8 +95,6 @@ class ResumeTrackingConfirmController: UIViewController, UIScrollViewDelegate {
         landmarkLabel.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 8.0).isActive = true
         landmarkLabel.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 8.0).isActive = true
         landmarkLabel.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -8.0).isActive = true
-//        landmarkLabel.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: -8.0).isActive = true
-
 
         /// set top, left, right AND bottom constraints on label to
         /// scrollView + 8.0 padding on each side

--- a/Clew/Controllers/StateViews/ResumeTrackingConfirmController.swift
+++ b/Clew/Controllers/StateViews/ResumeTrackingConfirmController.swift
@@ -20,13 +20,17 @@ class ResumeTrackingConfirmController: UIViewController, UIScrollViewDelegate {
     /// text label for the state
     var label: UILabel!
     
+    /// text for landmark information
+    var landmarkLabel: UILabel!
+    
     /// called when the view loads (any time)
     override func viewDidAppear(_ animated: Bool) {
         /// update label font
         /// TODO: is this a safe implementation? Might crash if label has no body, unclear.
         /// called when the view loads (any time)
         label.font = UIFont.preferredFont(forTextStyle: .body)
-        
+        landmarkLabel.font = UIFont.preferredFont(forTextStyle: .body)
+
         /// set confirm alignment button as initially active voiceover button
         UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: self.confirmAlignmentButton)
     }
@@ -41,12 +45,14 @@ class ResumeTrackingConfirmController: UIViewController, UIScrollViewDelegate {
                                                 height: UIScreen.main.bounds.size.height))
         
         label = UILabel()
+        landmarkLabel = UILabel()
         let scrollView = UIScrollView()
         
         /// allow for constraints to be applied to label, scrollview
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.indicatorStyle = .white;
         label.translatesAutoresizingMaskIntoConstraints = false
+        landmarkLabel.translatesAutoresizingMaskIntoConstraints = false
         
         /// darken background of view
         view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
@@ -65,8 +71,14 @@ class ResumeTrackingConfirmController: UIViewController, UIScrollViewDelegate {
         label.text = mainText
         label.tag = UIView.mainTextTag
         
+        landmarkLabel.textColor = UIColor.white
+        landmarkLabel.textAlignment = .center
+        landmarkLabel.numberOfLines = 0
+        landmarkLabel.lineBreakMode = .byWordWrapping
+        landmarkLabel.font = UIFont.preferredFont(forTextStyle: .body)
         
         /// place label inside of the scrollview
+        scrollView.addSubview(landmarkLabel)
         scrollView.addSubview(label)
         view.addSubview(scrollView)
         
@@ -79,9 +91,16 @@ class ResumeTrackingConfirmController: UIViewController, UIScrollViewDelegate {
         /// set the height constraint on the scrollView to 0.5 * the main view height
         scrollView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.5).isActive = true
         
+        /// constraints for landmarkLabel
+        landmarkLabel.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 8.0).isActive = true
+        landmarkLabel.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 8.0).isActive = true
+        landmarkLabel.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -8.0).isActive = true
+//        landmarkLabel.bottomAnchor.constraint(equalTo: label.bottomAnchor, constant: -8.0).isActive = true
+
+
         /// set top, left, right AND bottom constraints on label to
         /// scrollView + 8.0 padding on each side
-        label.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: 8.0).isActive = true
+        label.topAnchor.constraint(equalTo: landmarkLabel.bottomAnchor, constant: 8.0).isActive = true
         label.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor, constant: 8.0).isActive = true
         label.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor, constant: -8.0).isActive = true
         label.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -8.0).isActive = true
@@ -89,9 +108,13 @@ class ResumeTrackingConfirmController: UIViewController, UIScrollViewDelegate {
         /// set the width of the label to the width of the scrollView (-16 for 8.0 padding on each side)
         label.widthAnchor.constraint(equalTo: scrollView.widthAnchor, constant: -16.0).isActive = true
         
+        /// constraints for landmarkLabel
+        
         /// configure label: Zero lines + Word Wrapping
         label.numberOfLines = 0
         label.lineBreakMode = NSLineBreakMode.byWordWrapping
+        landmarkLabel.numberOfLines = 0
+        landmarkLabel.lineBreakMode = NSLineBreakMode.byWordWrapping
         
         // MARK: ReadVoiceNoteButton
         /// The button that plays back the recorded voice note associated with a landmark

--- a/Clew/Controllers/ViewController.swift
+++ b/Clew/Controllers/ViewController.swift
@@ -1125,8 +1125,10 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
         voiceNoteToPlay = nil
         if navigateStartToEnd {
             if let landmarkInformation = route.beginRouteLandmark.information as String? {
-                resumeTrackingConfirmController.label.text?.append("\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n")
-
+                let infoString = "\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n"
+                if let cacheText = resumeTrackingConfirmController.label.text {
+                    resumeTrackingConfirmController.label.text = infoString + cacheText
+                }
             }
             if let beginRouteLandmarkVoiceNote = route.beginRouteLandmark.voiceNote {
                 let voiceNoteToPlayURL = beginRouteLandmarkVoiceNote.documentURL
@@ -1138,7 +1140,10 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
             }
         } else {
             if let landmarkInformation = route.endRouteLandmark.information as String? {
-                resumeTrackingConfirmController.label.text?.append("\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n")
+                let infoString = "\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n"
+                if let cacheText = resumeTrackingConfirmController.label.text {
+                    resumeTrackingConfirmController.label.text = infoString + cacheText
+                }
             }
             if let endRouteLandmarkVoiceNote = route.endRouteLandmark.voiceNote {
                 let voiceNoteToPlayURL = endRouteLandmarkVoiceNote.documentURL

--- a/Clew/Controllers/ViewController.swift
+++ b/Clew/Controllers/ViewController.swift
@@ -1126,9 +1126,8 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
         if navigateStartToEnd {
             if let landmarkInformation = route.beginRouteLandmark.information as String? {
                 let infoString = "\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n"
-                if let cacheText = resumeTrackingConfirmController.label.text {
-                    resumeTrackingConfirmController.label.text = infoString + cacheText
-                }
+                resumeTrackingConfirmController.landmarkLabel.text = infoString
+
             }
             if let beginRouteLandmarkVoiceNote = route.beginRouteLandmark.voiceNote {
                 let voiceNoteToPlayURL = beginRouteLandmarkVoiceNote.documentURL
@@ -1141,9 +1140,7 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
         } else {
             if let landmarkInformation = route.endRouteLandmark.information as String? {
                 let infoString = "\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n"
-                if let cacheText = resumeTrackingConfirmController.label.text {
-                    resumeTrackingConfirmController.label.text = infoString + cacheText
-                }
+                resumeTrackingConfirmController.landmarkLabel.text = infoString
             }
             if let endRouteLandmarkVoiceNote = route.endRouteLandmark.voiceNote {
                 let voiceNoteToPlayURL = endRouteLandmarkVoiceNote.documentURL

--- a/Clew/Controllers/ViewController.swift
+++ b/Clew/Controllers/ViewController.swift
@@ -1125,7 +1125,8 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
         voiceNoteToPlay = nil
         if navigateStartToEnd {
             if let landmarkInformation = route.beginRouteLandmark.information as String? {
-                resumeTrackingConfirmController.view.mainText?.text?.append("The landmark information you entered is: " + landmarkInformation + ".\n\n")
+                resumeTrackingConfirmController.label.text?.append("\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n")
+
             }
             if let beginRouteLandmarkVoiceNote = route.beginRouteLandmark.voiceNote {
                 let voiceNoteToPlayURL = beginRouteLandmarkVoiceNote.documentURL
@@ -1137,7 +1138,7 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
             }
         } else {
             if let landmarkInformation = route.endRouteLandmark.information as String? {
-                resumeTrackingConfirmController.view.mainText?.text?.append("The landmark information you entered is: " + landmarkInformation + ".\n\n")
+                resumeTrackingConfirmController.label.text?.append("\n\n" + "The landmark information you entered is: " + landmarkInformation + "\n\n")
             }
             if let endRouteLandmarkVoiceNote = route.endRouteLandmark.voiceNote {
                 let voiceNoteToPlayURL = endRouteLandmarkVoiceNote.documentURL


### PR DESCRIPTION
This PR adds back functionality broken in a previous commit which slipped under the radar. Landmark information was not being shown in resumeTrackingConfirmController due to a change in how the labels are handled after the constraint refactor. Now, the text is correctly added to the top of the label in this view.