### PR TITLE
Fix consent form

### DIFF
--- a/Clew/Controllers/ViewController.swift
+++ b/Clew/Controllers/ViewController.swift
@@ -1066,6 +1066,7 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
             }
         }
         #if !APPCLIP
+        arLogger.enabled = UserDefaults.standard.bool(forKey: "hasconsented")
         arLogger.startTrial()
         #endif
     }

--- a/Clew/Controllers/ViewController.swift
+++ b/Clew/Controllers/ViewController.swift
@@ -1066,7 +1066,7 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
             }
         }
         #if !APPCLIP
-        arLogger.enabled = UserDefaults.standard.bool(forKey: "hasconsented")
+        arLogger.enabled = logRichData
         arLogger.startTrial()
         #endif
     }

--- a/Clew/Controllers/ViewController.swift
+++ b/Clew/Controllers/ViewController.swift
@@ -1386,6 +1386,8 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
         timerLength = defaults.integer(forKey: "timerLength")
         adjustOffset = defaults.bool(forKey: "adjustOffset")
         nav.useHeadingOffset = adjustOffset
+        logRichData = defaults.bool(forKey: "logRichData")
+
         #if CLEWMORE
         imageAnchoring = true
         #else
@@ -2223,6 +2225,9 @@ class ViewController: UIViewController, ARSCNViewDelegate, SRCountdownTimerDeleg
     
     /// The length of time that the timer will run for
     var timerLength: Int!
+    
+    /// This tracks whether the user has consented to log rich (image) data
+    var logRichData: Bool!
 
     /// This keeps track of the paused transform while the current session is being realigned to the saved route
     var pausedTransform : simd_float4x4?

--- a/Clew/Experiment/InformedConsentView.swift
+++ b/Clew/Experiment/InformedConsentView.swift
@@ -63,6 +63,7 @@ struct InformedConsentView : View {
                                  }
                                 // set hasconsented key to false
                                 UserDefaults.standard.setValue(false, forKey: "hasconsented")
+                                
 
                                 // redirect to home UI
                                 let vc = ViewController()

--- a/Clew/Experiment/InformedConsentView.swift
+++ b/Clew/Experiment/InformedConsentView.swift
@@ -36,25 +36,42 @@ struct InformedConsentView : View {
                         }
                         .padding([.leading, .top, .trailing], 8)
                         
-                        
-                        Button(informedConsentModel.didEnterValidEmail ? "Consent to Participate" : "Please enter your email address") {
-                            // TODO redirect to main UI
-                            guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-                                  let sceneDelegate = windowScene.delegate as? SceneDelegate, let uid = Auth.auth().currentUser?.uid
-                              else {
-                                return
-                              }
-                            let ref = Database.database().reference().child("appclipexperiment").child("emails").child(uid)
-                            print(ref.url)
-                            ref.setValue(["email": informedConsentModel.userEmail])
-                            UserDefaults.standard.setValue(true, forKey: "hasconsented")
-                            
-                              let vc = ViewController()
+                        VStack {
+                            Button(informedConsentModel.didEnterValidEmail ? "Consent to Participate" : "Please enter your email address") {
+                                guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                                      let sceneDelegate = windowScene.delegate as? SceneDelegate, let uid = Auth.auth().currentUser?.uid
+                                  else {
+                                    return
+                                  }
+                                let ref = Database.database().reference().child("appclipexperiment").child("emails").child(uid)
+                                print(ref.url)
+                                ref.setValue(["email": informedConsentModel.userEmail])
+                                UserDefaults.standard.setValue(true, forKey: "hasconsented")
+                                
+                                let vc = ViewController()
 
-                              sceneDelegate.window?.rootViewController = vc
+                                sceneDelegate.window?.rootViewController = vc
+                            }
+                            .disabled(!informedConsentModel.didEnterValidEmail)
+                            .padding([.leading, .top, .trailing], 8)
+                            
+                            Button("or Continue without data logging") {
+                               guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                                     let sceneDelegate = windowScene.delegate as? SceneDelegate, let uid = Auth.auth().currentUser?.uid
+                                 else {
+                                   return
+                                 }
+                                // set hasconsented key to false
+                                UserDefaults.standard.setValue(false, forKey: "hasconsented")
+
+                                // redirect to home UI
+                                let vc = ViewController()
+
+                                sceneDelegate.window?.rootViewController = vc
+                            }
+                            .padding([.leading, .top, .trailing], 8)
+
                         }
-                        .disabled(!informedConsentModel.didEnterValidEmail)
-                        .padding([.leading, .top, .trailing], 8)
                     }
                     .padding()
                 }
@@ -64,9 +81,9 @@ struct InformedConsentView : View {
             .onAppear {
                 // TODO: check if we need to login
             }
-            
+        }
     }
-}
+    
 
 #if DEBUG
 struct InformedConsentView_Previews : PreviewProvider {

--- a/Clew/Experiment/InformedConsentView.swift
+++ b/Clew/Experiment/InformedConsentView.swift
@@ -63,10 +63,12 @@ struct InformedConsentView : View {
                                  }
                                 // set hasconsented key to false
                                 UserDefaults.standard.setValue(false, forKey: "hasconsented")
-                                
 
                                 // redirect to home UI
                                 let vc = ViewController()
+                                
+                                // set logRichData toggle in settings to false
+                                vc.logRichData = false
 
                                 sceneDelegate.window?.rootViewController = vc
                             }

--- a/Clew/Settings.bundle/Root.plist
+++ b/Clew/Settings.bundle/Root.plist
@@ -8,6 +8,22 @@
 	<array>
 		<dict>
 			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+			<key>Title</key>
+			<string>Testing Options</string>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
+			<string>Log Rich Data (Images)</string>
+			<key>Key</key>
+			<string>logRichData</string>
+			<key>DefaultValue</key>
+			<true/>
+		</dict>
+		<dict>
+			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
 			<string>Align Routes From Image Anchors</string>


### PR DESCRIPTION
Implement workaround where a user can bypass the consent form for the research study, and their rich data won't be logged.